### PR TITLE
feat(web): replace share format select with combobox component

### DIFF
--- a/web/src/components/CombineForm.tsx
+++ b/web/src/components/CombineForm.tsx
@@ -4,6 +4,7 @@ import type { Strings } from "../i18n";
 import { ensureWasm } from "../wasm";
 
 import { CopyButton } from "./CopyButton";
+import { Combobox, type ComboboxOption } from "./ui/combobox";
 import { EncryptedText } from "./ui/encrypted-text";
 
 type Encoding = "base64url" | "mnemo-words";
@@ -112,6 +113,22 @@ export function CombineForm({ strings }: CombineFormProps) {
   const pasteRequestedRef = useRef(false);
   const flashTimeoutRef = useRef<number | null>(null);
 
+  const encodingOptions: ComboboxOption<Encoding>[] = useMemo(
+    () => [
+      {
+        value: "mnemo-words",
+        label: strings.encodingMnemoWords,
+        description: strings.encodingMnemoWordsDesc,
+      },
+      {
+        value: "base64url",
+        label: strings.encodingBase64url,
+        description: strings.encodingBase64urlDesc,
+      },
+    ],
+    [strings]
+  );
+
   const triggerEncodingFlash = useCallback(() => {
     setEncodingFlash(true);
     if (flashTimeoutRef.current !== null) {
@@ -215,20 +232,16 @@ export function CombineForm({ strings }: CombineFormProps) {
 
       <div className="mt-6 grid grid-cols-1 gap-4">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <label className="block text-start">
+          <div className="block text-start">
             <span className="field-label" id="encoding-label">{strings.encodingLabel}</span>
-            <select
+            <Combobox
               value={encoding}
-              onChange={(e) => setEncoding(e.target.value as Encoding)}
-              className={`input mt-2 transition-colors duration-1000 ease-out ${
-                encodingFlash ? "border-emerald-300/70 bg-emerald-500/10" : ""
-              }`}
+              onChange={setEncoding}
+              options={encodingOptions}
               aria-labelledby="encoding-label"
-            >
-              <option value="base64url">Letters (base64url)</option>
-              <option value="mnemo-words">Words (mnemo-words)</option>
-            </select>
-          </label>
+              flash={encodingFlash}
+            />
+          </div>
 
           <label className="block text-start">
             <span className="field-label" id="passphrase-label">{strings.passphraseLabel}</span>

--- a/web/src/components/SplitForm.tsx
+++ b/web/src/components/SplitForm.tsx
@@ -4,6 +4,7 @@ import type { Strings } from "../i18n";
 import { ensureWasm } from "../wasm";
 
 import { CopyButton } from "./CopyButton";
+import { Combobox, type ComboboxOption } from "./ui/combobox";
 import { EncryptedText } from "./ui/encrypted-text";
 
 type Encoding = "base64url" | "mnemo-words";
@@ -42,6 +43,22 @@ export function SplitForm({ strings }: SplitFormProps) {
   const [shares, setShares] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  const encodingOptions: ComboboxOption<Encoding>[] = useMemo(
+    () => [
+      {
+        value: "mnemo-words",
+        label: strings.encodingMnemoWords,
+        description: strings.encodingMnemoWordsDesc,
+      },
+      {
+        value: "base64url",
+        label: strings.encodingBase64url,
+        description: strings.encodingBase64urlDesc,
+      },
+    ],
+    [strings]
+  );
 
   const canSplit = useMemo(
     () => secret.length > 0 && k >= 2 && n >= 2 && n <= 255,
@@ -130,20 +147,17 @@ export function SplitForm({ strings }: SplitFormProps) {
             />
           </label>
 
-          <label className="block">
+          <div className="block">
             <span className="field-label block sm:min-h-10" id="encoding-label">
               {strings.encodingLabel}
             </span>
-            <select
+            <Combobox
               value={encoding}
-              onChange={(e) => setEncoding(e.target.value as Encoding)}
-              className="input mt-2"
+              onChange={setEncoding}
+              options={encodingOptions}
               aria-labelledby="encoding-label"
-            >
-              <option value="base64url">Letters (base64url)</option>
-              <option value="mnemo-words">Words (mnemo-words)</option>
-            </select>
-          </label>
+            />
+          </div>
         </div>
 
         <label className="block">

--- a/web/src/components/ui/combobox.tsx
+++ b/web/src/components/ui/combobox.tsx
@@ -1,0 +1,281 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import { cn } from "../../lib/cn";
+
+export type ComboboxOption<T extends string = string> = {
+  value: T;
+  label: string;
+  description?: string;
+};
+
+type ComboboxProps<T extends string = string> = {
+  value: T;
+  onChange: (value: T) => void;
+  options: ComboboxOption<T>[];
+  /** ARIA label for the combobox */
+  "aria-labelledby"?: string;
+  /** Additional class names for the trigger button */
+  className?: string;
+  /** Show flash animation (e.g., when auto-detected) */
+  flash?: boolean;
+};
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={cn(
+        "h-4 w-4 shrink-0 text-slate-400 transition-transform duration-200",
+        open && "rotate-180"
+      )}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M5.23 7.21a.75.75 0 011.06.02L10 11.293l3.71-4.063a.75.75 0 111.1 1.02l-4.25 4.657a.75.75 0 01-1.11 0L5.21 8.27a.75.75 0 01.02-1.06z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className="h-4 w-4 text-emerald-400"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function Combobox<T extends string = string>({
+  value,
+  onChange,
+  options,
+  "aria-labelledby": ariaLabelledby,
+  className,
+  flash,
+}: ComboboxProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+  const triggerId = useId();
+
+  const selectedOption = options.find((o) => o.value === value);
+  const selectedIndex = options.findIndex((o) => o.value === value);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        listboxRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+
+    function handleEscape(e: globalThis.KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open]);
+
+  // Reset focused index when opening
+  useEffect(() => {
+    if (open) {
+      setFocusedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    }
+  }, [open, selectedIndex]);
+
+  // Scroll focused option into view
+  useEffect(() => {
+    if (!open || focusedIndex < 0) return;
+    const listbox = listboxRef.current;
+    const focusedEl = listbox?.children[focusedIndex] as HTMLElement | undefined;
+    focusedEl?.scrollIntoView({ block: "nearest" });
+  }, [open, focusedIndex]);
+
+  const selectOption = useCallback(
+    (opt: ComboboxOption<T>) => {
+      onChange(opt.value);
+      setOpen(false);
+      triggerRef.current?.focus();
+    },
+    [onChange]
+  );
+
+  const handleTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    switch (e.key) {
+      case "ArrowDown":
+      case "ArrowUp":
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        setOpen(true);
+        break;
+    }
+  };
+
+  const handleListKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setFocusedIndex((prev) =>
+          prev < options.length - 1 ? prev + 1 : 0
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setFocusedIndex((prev) =>
+          prev > 0 ? prev - 1 : options.length - 1
+        );
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (focusedIndex >= 0 && focusedIndex < options.length) {
+          selectOption(options[focusedIndex]);
+        }
+        break;
+      case "Home":
+        e.preventDefault();
+        setFocusedIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setFocusedIndex(options.length - 1);
+        break;
+      case "Tab":
+        setOpen(false);
+        break;
+    }
+  };
+
+  return (
+    <div className="relative">
+      {/* Trigger Button */}
+      <button
+        ref={triggerRef}
+        id={triggerId}
+        type="button"
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-labelledby={ariaLabelledby}
+        aria-activedescendant={
+          open && focusedIndex >= 0 ? `${listId}-opt-${focusedIndex}` : undefined
+        }
+        onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={handleTriggerKeyDown}
+        className={cn(
+          "input mt-2 flex items-center justify-between gap-2 text-start transition-colors duration-1000 ease-out",
+          flash && "border-emerald-300/70 bg-emerald-500/10",
+          className
+        )}
+      >
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate">{selectedOption?.label}</span>
+          {selectedOption?.description && (
+            <span className="truncate text-xs text-slate-400">
+              {selectedOption.description}
+            </span>
+          )}
+        </span>
+        <ChevronIcon open={open} />
+      </button>
+
+      {/* Dropdown Listbox */}
+      {open && (
+        <div
+          ref={listboxRef}
+          id={listId}
+          role="listbox"
+          aria-labelledby={ariaLabelledby}
+          tabIndex={0}
+          onKeyDown={handleListKeyDown}
+          className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-xl border border-emerald-500/20 bg-black/95 py-1 shadow-xl shadow-emerald-500/10 backdrop-blur-xl focus:outline-none"
+          style={{ minWidth: "100%" }}
+        >
+          {options.map((opt, idx) => {
+            const isSelected = opt.value === value;
+            const isFocused = idx === focusedIndex;
+
+            return (
+              <div
+                key={opt.value}
+                id={`${listId}-opt-${idx}`}
+                role="option"
+                aria-selected={isSelected}
+                tabIndex={-1}
+                onClick={() => selectOption(opt)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    selectOption(opt);
+                  }
+                }}
+                onMouseEnter={() => setFocusedIndex(idx)}
+                className={cn(
+                  "dir-row cursor-pointer items-center gap-3 px-3 py-2.5 text-sm transition-colors",
+                  isFocused && "bg-emerald-500/15",
+                  isSelected && "text-emerald-300"
+                )}
+              >
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate font-medium">{opt.label}</span>
+                  {opt.description && (
+                    <span className="truncate text-xs text-slate-400">
+                      {opt.description}
+                    </span>
+                  )}
+                </span>
+                {isSelected && (
+                  <span className="shrink-0">
+                    <CheckIcon />
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -31,6 +31,10 @@ export const STRINGS = {
     kLabel: "Minimum shares to recover (k)",
     nLabel: "Total shares to create (n)",
     encodingLabel: "Share format",
+    encodingBase64url: "Letters",
+    encodingBase64urlDesc: "Compact alphanumeric (base64url)",
+    encodingMnemoWords: "Words",
+    encodingMnemoWordsDesc: "Easy to write mnemonic words",
     passphraseLabel: "Passphrase (optional)",
 
     splitCta: "Split",
@@ -88,6 +92,10 @@ export const STRINGS = {
     kLabel: "الحد الأدنى للاستعادة (k)",
     nLabel: "إجمالي الحصص (n)",
     encodingLabel: "صيغة الحصة",
+    encodingBase64url: "أحرف",
+    encodingBase64urlDesc: "أحرف وأرقام مضغوطة (base64url)",
+    encodingMnemoWords: "كلمات",
+    encodingMnemoWordsDesc: "كلمات سهلة الكتابة",
     passphraseLabel: "عبارة مرور (اختياري)",
 
     splitCta: "قسم",


### PR DESCRIPTION
## Summary

- Replaces native HTML `<select>` with a custom, accessible combobox for share format selection
- Shows label and description for each encoding option (Words/Letters)
- Supports RTL (Arabic) with proper text alignment and direction
- Maintains the auto-detection flash animation in Combine form
- Full keyboard navigation (Arrow keys, Enter, Escape, Home, End)

## Changes

- **New component**: `web/src/components/ui/combobox.tsx` - reusable combobox with ARIA compliance
- **Updated**: SplitForm and CombineForm to use the new Combobox
- **Updated**: i18n.ts with encoding option labels/descriptions (EN/AR)

## Screenshots

The combobox displays both the label and a helpful description for each option, making it clearer what each encoding format means.