### PR TITLE
feat(web): keyboard shortcuts

### DIFF
--- a/web/src/components/CombineForm.tsx
+++ b/web/src/components/CombineForm.tsx
@@ -328,6 +328,7 @@ export function CombineForm({ strings }: CombineFormProps) {
         <div className="dir-row flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
           <button
             type="button"
+            data-shortcut="submit"
             disabled={!canCombine || busy}
             onClick={onCombine}
             className="btn-primary w-full sm:w-auto"

--- a/web/src/components/KeyboardShortcutsHelp.tsx
+++ b/web/src/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import type { Lang, Strings } from "../i18n";
+import { cn } from "../lib/cn";
+
+type ShortcutRow = {
+  keys: string;
+  action: string;
+};
+
+type KeyboardShortcutsHelpProps = {
+  open: boolean;
+  lang: Lang;
+  strings: Strings;
+  onClose: () => void;
+};
+
+function kbdLabel(keys: string) {
+  return (
+    <span
+      dir="ltr"
+      className="inline-flex items-center gap-1 font-mono text-[11px] text-slate-200"
+    >
+      {keys.split("+").map((k, i) => (
+        <span
+          key={`${i}-${k}`}
+          className="rounded-md border border-emerald-500/20 bg-black/40 px-2 py-1"
+        >
+          {k.trim()}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function focusableElements(container: HTMLElement): HTMLElement[] {
+  const nodes = container.querySelectorAll<HTMLElement>(
+    'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+  );
+  return Array.from(nodes).filter((el) => !el.hasAttribute("disabled"));
+}
+
+export function KeyboardShortcutsHelp({
+  open,
+  lang,
+  strings,
+  onClose,
+}: KeyboardShortcutsHelpProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const lastFocusedRef = useRef<HTMLElement | null>(null);
+
+  const rows = useMemo((): ShortcutRow[] => {
+    const ctrlOrCmd = "Ctrl/Cmd";
+
+    return [
+      { keys: "1", action: strings.shortcutGoToSplit },
+      { keys: "2", action: strings.shortcutGoToCombine },
+      { keys: "?", action: strings.shortcutShowHelp },
+      { keys: `${ctrlOrCmd}+Enter`, action: strings.shortcutSubmitForm },
+      { keys: `${ctrlOrCmd}+Shift+C`, action: strings.shortcutCopyResult },
+    ];
+  }, [strings]);
+
+  useEffect(() => {
+    if (!open) return;
+    lastFocusedRef.current = document.activeElement as HTMLElement | null;
+    closeButtonRef.current?.focus();
+    return () => {
+      lastFocusedRef.current?.focus();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const items = focusableElements(dialog);
+      if (items.length === 0) return;
+
+      const first = items[0];
+      const last = items[items.length - 1];
+
+      const active = document.activeElement as HTMLElement | null;
+      if (!active) return;
+
+      if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose, open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60]" aria-hidden={false}>
+      <button
+        type="button"
+        aria-label={strings.shortcutClose}
+        tabIndex={-1}
+        className="absolute inset-0 bg-black/55 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative mx-auto flex min-h-full max-w-2xl items-center px-4 py-6">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={strings.keyboardShortcuts}
+          className="glass w-full p-4 sm:p-6"
+        >
+          <div className="dir-row items-start justify-between gap-4">
+            <div className="text-start">
+              <h2 className="text-lg font-semibold text-emerald-100">
+                {strings.keyboardShortcuts}
+              </h2>
+              <p className="mt-1 text-xs text-slate-300">
+                {lang === "en"
+                  ? "These shortcuts work on desktop keyboards."
+                  : "تعمل هذه الاختصارات على لوحات المفاتيح."}
+              </p>
+            </div>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              className={cn(
+                "btn-ghost h-11 min-w-[44px] px-3 py-2 text-xs",
+                "shrink-0"
+              )}
+            >
+              {strings.shortcutClose}
+            </button>
+          </div>
+
+          <div className="mt-4 overflow-hidden rounded-xl border border-emerald-500/15 bg-black/35">
+            <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 p-3 sm:p-4">
+              {rows.map((row) => (
+                <div
+                  key={`${row.keys}-${row.action}`}
+                  className="contents"
+                >
+                  <div className="text-start">{kbdLabel(row.keys)}</div>
+                  <div className="text-start text-sm text-slate-200">
+                    {row.action}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <p className="mt-3 text-xs text-slate-400">
+            {lang === "en"
+              ? "Tip: use Left/Right arrows on the Split/Combine tabs."
+              : "تلميح: استخدم السهمين يمينا ويسارا على تبويبات التقسيم والاستعادة."}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SplitForm.tsx
+++ b/web/src/components/SplitForm.tsx
@@ -175,6 +175,7 @@ export function SplitForm({ strings }: SplitFormProps) {
         <div className="dir-row flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
           <button
             type="button"
+            data-shortcut="submit"
             disabled={!canSplit || busy}
             onClick={onSplit}
             className="btn-primary w-full sm:w-auto"

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,154 @@
+import { useEffect } from "react";
+
+import type { Strings } from "../i18n";
+
+type Tab = "split" | "combine";
+
+type ShortcutHandlers = {
+  tab: Tab;
+  setTab: (tab: Tab) => void;
+  focusTab: (tab: Tab) => void;
+  helpOpen: boolean;
+  openHelp: () => void;
+  closeHelp: () => void;
+  strings: Strings;
+  announce: (message: string, type?: "polite" | "assertive") => void;
+};
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return target.isContentEditable;
+}
+
+async function copyToClipboard(text: string) {
+  if (
+    typeof navigator !== "undefined" &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === "function"
+  ) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}
+
+function collectSplitSharesText(): string | null {
+  const panel = document.getElementById("split-panel");
+  if (!panel) return null;
+  const shareBlocks = Array.from(
+    panel.querySelectorAll<HTMLDivElement>('div[dir="ltr"].input')
+  )
+    .map((el) => el.innerText.trim())
+    .filter(Boolean);
+  if (shareBlocks.length === 0) return null;
+  return shareBlocks.join("\n\n");
+}
+
+function collectCombineResultText(): string | null {
+  const panel = document.getElementById("combine-panel");
+  if (!panel) return null;
+  const recovered = panel.querySelector<HTMLDivElement>('div[dir="auto"].input');
+  const text = recovered?.innerText.trim();
+  return text ? text : null;
+}
+
+function clickSubmit(tab: Tab) {
+  const panelId = tab === "split" ? "split-panel" : "combine-panel";
+  const panel = document.getElementById(panelId);
+  const btn = panel?.querySelector<HTMLButtonElement>(
+    'button[data-shortcut="submit"]'
+  );
+  btn?.click();
+}
+
+export function useKeyboardShortcuts({
+  tab,
+  setTab,
+  focusTab,
+  helpOpen,
+  openHelp,
+  closeHelp,
+  strings,
+  announce,
+}: ShortcutHandlers) {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.isComposing) return;
+      if (e.defaultPrevented) return;
+
+      // Avoid competing with browser/OS shortcuts.
+      if (e.altKey) return;
+
+      const editable = isEditableTarget(e.target);
+
+      // Dismiss help
+      if (helpOpen && e.key === "Escape") {
+        e.preventDefault();
+        closeHelp();
+        return;
+      }
+
+      if (helpOpen) return;
+
+      // Toggle shortcuts help
+      if (!editable && !e.ctrlKey && !e.metaKey && e.key === "?") {
+        e.preventDefault();
+        if (helpOpen) closeHelp();
+        else openHelp();
+        return;
+      }
+
+      // Global tab switching (avoid when typing)
+      if (!editable && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        if (e.key === "1") {
+          e.preventDefault();
+          setTab("split");
+          focusTab("split");
+          return;
+        }
+        if (e.key === "2") {
+          e.preventDefault();
+          setTab("combine");
+          focusTab("combine");
+          return;
+        }
+      }
+
+      // Submit form
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+        e.preventDefault();
+        clickSubmit(tab);
+        return;
+      }
+
+      // Copy result
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === "C" || e.key === "c")) {
+        const text = tab === "split" ? collectSplitSharesText() : collectCombineResultText();
+        if (!text) return;
+        e.preventDefault();
+        copyToClipboard(text)
+          .then(() => announce(strings.copied, "polite"))
+          .catch(() => {
+            // ignore
+          });
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [announce, closeHelp, focusTab, helpOpen, openHelp, setTab, strings.copied, tab]);
+}

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -62,6 +62,14 @@ export const STRINGS = {
     wasmCommand: "bun run build:wasm",
 
     errorWasmMissing: "WASM module not found. Run bun run build:wasm.",
+
+    keyboardShortcuts: "Keyboard shortcuts",
+    shortcutClose: "Close",
+    shortcutGoToSplit: "Go to Split",
+    shortcutGoToCombine: "Go to Combine",
+    shortcutSubmitForm: "Submit form",
+    shortcutCopyResult: "Copy result",
+    shortcutShowHelp: "Show shortcuts",
   },
   ar: {
     appName: "Safeparts",
@@ -123,6 +131,14 @@ export const STRINGS = {
     wasmCommand: "bun run build:wasm",
 
     errorWasmMissing: "لم يتم العثور على WASM. شغل bun run build:wasm.",
+
+    keyboardShortcuts: "اختصارات لوحة المفاتيح",
+    shortcutClose: "إغلاق",
+    shortcutGoToSplit: "الذهاب للتقسيم",
+    shortcutGoToCombine: "الذهاب للاستعادة",
+    shortcutSubmitForm: "إرسال النموذج",
+    shortcutCopyResult: "نسخ النتيجة",
+    shortcutShowHelp: "عرض الاختصارات",
   },
 } as const;
 


### PR DESCRIPTION
## Design

- Shortcuts are discoverable via `?` (modal) and a small header button (hidden on small screens).
- Single-key shortcuts avoid interfering with typing by only firing when focus is not in an editable field.
- Power shortcuts use standard combos (Ctrl/Cmd+Enter, Ctrl/Cmd+Shift+C) and work from inputs.
- No persistent shortcut hints in the UI.

## Implemented shortcuts

- `1`: go to Split tab (when not typing)
- `2`: go to Combine tab (when not typing)
- `?`: open/close shortcuts help (when not typing)
- `Ctrl/Cmd+Enter`: submit active form (Split/Combine)
- `Ctrl/Cmd+Shift+C`: copy result (Split shares / Combine recovered secret)
- Tabs: Left/Right + Home/End roving focus + RTL-aware

## Accessibility

- Help modal uses `role=dialog` + `aria-modal`, focus is moved into dialog and restored on close, and focus is trapped while open.
- Tablist navigation follows ARIA expectations, including roving `tabIndex`.

## Files

- `web/src/hooks/useKeyboardShortcuts.ts`
- `web/src/components/KeyboardShortcutsHelp.tsx`
- `web/src/App.tsx`
- `web/src/i18n.ts`
- `web/src/components/SplitForm.tsx`
- `web/src/components/CombineForm.tsx`