### PR TITLE
fix(web): improve mobile number input UX

### DIFF
--- a/web/src/components/SplitForm.tsx
+++ b/web/src/components/SplitForm.tsx
@@ -27,7 +27,10 @@ export function SplitForm({ strings }: SplitFormProps) {
   const [secret, setSecret] = useState("");
   const [k, setK] = useState(2);
   const [n, setN] = useState(3);
-  const [isCoarsePointer, setIsCoarsePointer] = useState(false);
+  const [isCoarsePointer, setIsCoarsePointer] = useState(() => {
+    const media = typeof window !== "undefined" ? window.matchMedia?.("(pointer: coarse)") : null;
+    return media?.matches ?? false;
+  });
 
   useEffect(() => {
     const media = typeof window !== "undefined" ? window.matchMedia?.("(pointer: coarse)") : null;
@@ -159,88 +162,116 @@ export function SplitForm({ strings }: SplitFormProps) {
         </label>
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          <label className="block">
+          <label className="block" htmlFor="split-k">
             <span className="field-label block sm:min-h-10" id="k-label">
               {strings.kLabel}
             </span>
-            <div className="relative mt-2">
+            {isCoarsePointer ? (
+              <div className="input-stepper-shell mt-2">
+                <input
+                  id="split-k"
+                  type="number"
+                  inputMode="numeric"
+                  min={2}
+                  max={Math.min(255, n)}
+                  value={k}
+                  onChange={(e) => setK(clampK(Number(e.target.value), n))}
+                  onFocus={selectAllOnFocus}
+                  onClick={selectAllOnClick}
+                  className="input-stepper-field"
+                  aria-labelledby="k-label"
+                />
+                <div className="stepper-controls items-center gap-1 p-1">
+                  <button
+                    type="button"
+                    className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => setK((prev) => clampK(prev - 1, n))}
+                    disabled={k <= 2}
+                    aria-label={strings.decrement}
+                    title={strings.decrement}
+                  >
+                    −
+                  </button>
+                  <button
+                    type="button"
+                    className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => setK((prev) => clampK(prev + 1, n))}
+                    disabled={k >= Math.min(255, n)}
+                    aria-label={strings.increment}
+                    title={strings.increment}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            ) : (
               <input
+                id="split-k"
                 type="number"
-                inputMode="numeric"
                 min={2}
                 max={Math.min(255, n)}
                 value={k}
                 onChange={(e) => setK(clampK(Number(e.target.value), n))}
-                onFocus={selectAllOnFocus}
-                onClick={selectAllOnClick}
-                className="input input-with-stepper"
+                className="input mt-2"
                 aria-labelledby="k-label"
               />
-              <div className="stepper-controls absolute top-1/2 -translate-y-1/2 end-2 items-center gap-1">
-                <button
-                  type="button"
-                  className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
-                  onClick={() => setK((prev) => clampK(prev - 1, n))}
-                  disabled={k <= 2}
-                  aria-label={strings.decrement}
-                  title={strings.decrement}
-                >
-                  −
-                </button>
-                <button
-                  type="button"
-                  className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
-                  onClick={() => setK((prev) => clampK(prev + 1, n))}
-                  disabled={k >= Math.min(255, n)}
-                  aria-label={strings.increment}
-                  title={strings.increment}
-                >
-                  +
-                </button>
-              </div>
-            </div>
+            )}
           </label>
 
-          <label className="block">
+          <label className="block" htmlFor="split-n">
             <span className="field-label block sm:min-h-10" id="n-label">
               {strings.nLabel}
             </span>
-            <div className="relative mt-2">
+            {isCoarsePointer ? (
+              <div className="input-stepper-shell mt-2">
+                <input
+                  id="split-n"
+                  type="number"
+                  inputMode="numeric"
+                  min={2}
+                  max={255}
+                  value={n}
+                  onChange={(e) => setNClamped(Number(e.target.value))}
+                  onFocus={selectAllOnFocus}
+                  onClick={selectAllOnClick}
+                  className="input-stepper-field"
+                  aria-labelledby="n-label"
+                />
+                <div className="stepper-controls items-center gap-1 p-1">
+                  <button
+                    type="button"
+                    className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => setNClamped(n - 1)}
+                    disabled={n <= 2}
+                    aria-label={strings.decrement}
+                    title={strings.decrement}
+                  >
+                    −
+                  </button>
+                  <button
+                    type="button"
+                    className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => setNClamped(n + 1)}
+                    disabled={n >= 255}
+                    aria-label={strings.increment}
+                    title={strings.increment}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            ) : (
               <input
+                id="split-n"
                 type="number"
-                inputMode="numeric"
                 min={2}
                 max={255}
                 value={n}
                 onChange={(e) => setNClamped(Number(e.target.value))}
-                onFocus={selectAllOnFocus}
-                onClick={selectAllOnClick}
-                className="input input-with-stepper"
+                className="input mt-2"
                 aria-labelledby="n-label"
               />
-              <div className="stepper-controls absolute top-1/2 -translate-y-1/2 end-2 items-center gap-1">
-                <button
-                  type="button"
-                  className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
-                  onClick={() => setNClamped(n - 1)}
-                  disabled={n <= 2}
-                  aria-label={strings.decrement}
-                  title={strings.decrement}
-                >
-                  −
-                </button>
-                <button
-                  type="button"
-                  className="grid h-10 w-10 place-items-center rounded-lg border border-emerald-500/15 bg-black/35 text-sm text-slate-200 hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
-                  onClick={() => setNClamped(n + 1)}
-                  disabled={n >= 255}
-                  aria-label={strings.increment}
-                  title={strings.increment}
-                >
-                  +
-                </button>
-              </div>
-            </div>
+            )}
           </label>
 
           <div className="block sm:col-span-3">

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -61,6 +61,8 @@ export const STRINGS = {
 
     copy: "Copy",
     copied: "Copied",
+    increment: "Increase",
+    decrement: "Decrease",
 
     wasmHint: "Before using this UI, run",
     wasmCommand: "bun run build:wasm",
@@ -135,6 +137,8 @@ export const STRINGS = {
 
     copy: "نسخ",
     copied: "تم النسخ",
+    increment: "زيادة",
+    decrement: "تقليل",
 
     wasmHint: "قبل استخدام الواجهة، شغل",
     wasmCommand: "bun run build:wasm",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -58,25 +58,37 @@
 
   /*
    * Mobile: numeric inputs have poor affordances on iOS (no steppers).
-   * We add custom +/- controls for coarse pointers without changing layout.
+   * Use custom +/- controls on coarse pointers.
    */
   .stepper-controls {
-    display: none;
+    display: flex;
   }
 
-  @media (pointer: coarse) {
+  @media (pointer: fine) {
     .stepper-controls {
-      display: flex;
+      display: none;
     }
+  }
 
-    .input-with-stepper {
-      padding-right: 5.5rem;
-    }
+  .input-stepper-shell {
+    @apply w-full rounded-xl border border-emerald-500/15 bg-black/40 text-sm text-slate-100 shadow-sm outline-none;
+    @apply focus-within:border-emerald-400 focus-within:ring-4 focus-within:ring-emerald-500/15;
+    display: flex;
+    align-items: stretch;
+  }
 
-    :dir(rtl) .input-with-stepper {
-      padding-left: 5.5rem;
-      padding-right: 0.75rem;
-    }
+  .input-stepper-field {
+    flex: 1 1 auto;
+    min-width: 0;
+    background: transparent;
+    border: 0;
+    outline: none;
+    padding: 0.5rem 0.75rem;
+    color: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    -webkit-appearance: none;
+    appearance: none;
   }
 
   .btn {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -56,6 +56,29 @@
     padding-right: 0.75rem;
   }
 
+  /*
+   * Mobile: numeric inputs have poor affordances on iOS (no steppers).
+   * We add custom +/- controls for coarse pointers without changing layout.
+   */
+  .stepper-controls {
+    display: none;
+  }
+
+  @media (pointer: coarse) {
+    .stepper-controls {
+      display: flex;
+    }
+
+    .input-with-stepper {
+      padding-right: 5.5rem;
+    }
+
+    :dir(rtl) .input-with-stepper {
+      padding-left: 5.5rem;
+      padding-right: 0.75rem;
+    }
+  }
+
   .btn {
     @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-medium shadow-sm transition active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black;


### PR DESCRIPTION
## Summary
- Improves iOS/mobile UX for `k`/`n` number inputs by adding touch-friendly +/- steppers.
- Auto-selects the current value on focus/tap (coarse pointers) to make editing faster.
- Keeps layout intact by reusing the existing grid and input sizing.

## Notes
- Stepper UI is shown only on coarse pointers; desktop behavior stays the same.

## Related
- Issue #15