### PR TITLE
feat(web): add contextual paste controls for input fields

### DIFF
--- a/web/src/components/ClearButton.tsx
+++ b/web/src/components/ClearButton.tsx
@@ -79,10 +79,10 @@ export function ClearButton({
       className={cn(
         "inline-flex items-center justify-center rounded-lg",
         "h-9 w-9",
-        "text-slate-400 hover:text-slate-200",
-        "bg-transparent hover:bg-white/5",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
-        "disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-slate-400",
+        "text-slate-400 transition-colors hover:text-slate-200",
+        "bg-transparent hover:bg-transparent",
+        "focus-visible:outline-none focus-visible:text-slate-100",
+        "disabled:opacity-25 disabled:hover:text-slate-400",
         className,
       )}
     >

--- a/web/src/components/CombineForm.tsx
+++ b/web/src/components/CombineForm.tsx
@@ -5,6 +5,7 @@ import { ensureWasm } from "../wasm";
 
 import { ClearButton } from "./ClearButton";
 import { CopyButton } from "./CopyButton";
+import { PasteButton } from "./PasteButton";
 import {
   EncodingSelector,
   type Encoding,
@@ -341,16 +342,23 @@ export function CombineForm({ strings }: CombineFormProps) {
             <input
               value={passphrase}
               onChange={(e) => setPassphrase(e.target.value)}
-              className="input input-with-clear"
+              className="input input-with-clear-compact"
               autoComplete="new-password"
               aria-labelledby="passphrase-label"
             />
-            <ClearButton
-              label={strings.clearPassphrase}
-              disabled={passphrase.length === 0}
-              onClick={() => setPassphrase("")}
-              className="absolute top-1/2 -translate-y-1/2 end-2"
-            />
+            {passphrase.length === 0 ? (
+              <PasteButton
+                label={strings.pastePassphrase}
+                onPaste={setPassphrase}
+                className="absolute inset-y-1 end-1 h-auto w-8 hover:bg-transparent"
+              />
+            ) : (
+              <ClearButton
+                label={strings.clearPassphrase}
+                onClick={() => setPassphrase("")}
+                className="absolute inset-y-1 end-1 h-auto w-8 hover:bg-transparent"
+              />
+            )}
           </div>
         </label>
 
@@ -412,12 +420,22 @@ export function CombineForm({ strings }: CombineFormProps) {
                       }
                       aria-invalid={isInvalid}
                     />
-                    <ClearButton
-                      label={`${strings.clearShare} ${i + 1}`}
-                      disabled={box.value.length === 0}
-                      onClick={() => setShareBoxValue(box.id, "")}
-                      className="absolute top-2 end-2"
-                    />
+                    {box.value.length === 0 ? (
+                      <PasteButton
+                        label={`${strings.pasteShare} ${i + 1}`}
+                        onPaste={(text) => {
+                          pasteRequestedRef.current = true;
+                          setShareBoxValue(box.id, text);
+                        }}
+                        className="absolute top-2 end-2"
+                      />
+                    ) : (
+                      <ClearButton
+                        label={`${strings.clearShare} ${i + 1}`}
+                        onClick={() => setShareBoxValue(box.id, "")}
+                        className="absolute top-2 end-2"
+                      />
+                    )}
                   </div>
                   {isInvalid && (
                     <p className="mt-1 text-xs text-rose-400" id={`share-${box.id}-error`} role="alert">

--- a/web/src/components/PasteButton.tsx
+++ b/web/src/components/PasteButton.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+
+import { cn } from "../lib/cn";
+
+type PasteButtonProps = {
+  label: string;
+  disabled?: boolean;
+  onPaste: (text: string) => void | Promise<void>;
+  className?: string;
+};
+
+function PasteIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className="h-4 w-4"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M9 4.5h6m-7 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12 9v5m0 0 2-2m-2 2-2-2"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.5 4.5a2.5 2.5 0 0 1 5 0"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function PasteButton({
+  label,
+  disabled = false,
+  onPaste,
+  className,
+}: PasteButtonProps) {
+  const [pasteSupported, setPasteSupported] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function detectPasteSupport() {
+      const hasClipboardReadText =
+        typeof navigator !== "undefined" &&
+        !!navigator.clipboard &&
+        typeof navigator.clipboard.readText === "function";
+      const secureContext =
+        typeof window === "undefined" ? true : window.isSecureContext;
+
+      if (!hasClipboardReadText || !secureContext) {
+        if (!cancelled) setPasteSupported(false);
+        return;
+      }
+
+      if (
+        typeof navigator === "undefined" ||
+        !navigator.permissions ||
+        typeof navigator.permissions.query !== "function"
+      ) {
+        if (!cancelled) setPasteSupported(false);
+        return;
+      }
+
+      try {
+        const status = await navigator.permissions.query({
+          name: "clipboard-read" as PermissionName,
+        });
+        if (!cancelled) setPasteSupported(status.state === "granted");
+      } catch {
+        if (!cancelled) setPasteSupported(false);
+      }
+    }
+
+    void detectPasteSupport();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!pasteSupported) return null;
+
+  async function onClick() {
+    if (disabled) return;
+
+    try {
+      const text = await navigator.clipboard.readText();
+      if (!text) return;
+      await onPaste(text);
+    } catch {
+      // Ignore clipboard failures (permissions, insecure context, etc.).
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "inline-flex items-center justify-center rounded-lg",
+        "h-9 w-9",
+        "text-slate-400 transition-colors hover:text-slate-200",
+        "bg-transparent hover:bg-transparent",
+        "focus-visible:outline-none focus-visible:text-slate-100",
+        "disabled:opacity-25 disabled:hover:text-slate-400",
+        className,
+      )}
+    >
+      <PasteIcon />
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}

--- a/web/src/components/SplitForm.tsx
+++ b/web/src/components/SplitForm.tsx
@@ -13,6 +13,7 @@ import { ensureWasm } from "../wasm";
 
 import { ClearButton } from "./ClearButton";
 import { CopyButton } from "./CopyButton";
+import { PasteButton } from "./PasteButton";
 import {
   EncodingSelector,
   type Encoding,
@@ -178,19 +179,33 @@ export function SplitForm({ strings }: SplitFormProps) {
               aria-labelledby="secret-label"
               aria-describedby="secret-hint"
             />
-            <ClearButton
-              label={strings.clearSecret}
-              disabled={secret.length === 0}
-              onClick={() => {
-                setSecret("");
-                requestAnimationFrame(() => {
-                  if (secretTextareaRef.current) {
-                    resizeSecretTextarea(secretTextareaRef.current);
-                  }
-                });
-              }}
-              className="absolute top-2 end-2"
-            />
+            {secret.length === 0 ? (
+              <PasteButton
+                label={strings.pasteSecret}
+                onPaste={(text) => {
+                  setSecret(text);
+                  requestAnimationFrame(() => {
+                    if (secretTextareaRef.current) {
+                      resizeSecretTextarea(secretTextareaRef.current);
+                    }
+                  });
+                }}
+                className="absolute top-2 end-2"
+              />
+            ) : (
+              <ClearButton
+                label={strings.clearSecret}
+                onClick={() => {
+                  setSecret("");
+                  requestAnimationFrame(() => {
+                    if (secretTextareaRef.current) {
+                      resizeSecretTextarea(secretTextareaRef.current);
+                    }
+                  });
+                }}
+                className="absolute top-2 end-2"
+              />
+            )}
           </div>
         </label>
 
@@ -321,16 +336,23 @@ export function SplitForm({ strings }: SplitFormProps) {
             <input
               value={passphrase}
               onChange={(e) => setPassphrase(e.target.value)}
-              className="input input-with-clear"
+              className="input input-with-clear-compact"
               autoComplete="new-password"
               aria-labelledby="passphrase-label"
             />
-            <ClearButton
-              label={strings.clearPassphrase}
-              disabled={passphrase.length === 0}
-              onClick={() => setPassphrase("")}
-              className="absolute top-1/2 -translate-y-1/2 end-2"
-            />
+            {passphrase.length === 0 ? (
+              <PasteButton
+                label={strings.pastePassphrase}
+                onPaste={setPassphrase}
+                className="absolute inset-y-1 end-1 h-auto w-8 hover:bg-transparent"
+              />
+            ) : (
+              <ClearButton
+                label={strings.clearPassphrase}
+                onClick={() => setPassphrase("")}
+                className="absolute inset-y-1 end-1 h-auto w-8 hover:bg-transparent"
+              />
+            )}
           </div>
         </label>
 

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -41,6 +41,9 @@ export const STRINGS = {
     clearSecret: "Clear secret",
     clearPassphrase: "Clear passphrase",
     clearShare: "Clear share",
+    pasteSecret: "Paste secret",
+    pastePassphrase: "Paste passphrase",
+    pasteShare: "Paste share",
 
     splitCta: "Split",
     combineCta: "Combine",
@@ -118,6 +121,9 @@ export const STRINGS = {
     clearSecret: "مسح السر",
     clearPassphrase: "مسح عبارة المرور",
     clearShare: "مسح الحصة",
+    pasteSecret: "لصق السر",
+    pastePassphrase: "لصق عبارة المرور",
+    pasteShare: "لصق الحصة",
 
     splitCta: "قسم",
     combineCta: "استعادة",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -51,8 +51,18 @@
     padding-right: 3rem;
   }
 
+  /* Compact inline action spacing for single-line fields. */
+  .input-with-clear-compact {
+    padding-right: 2.5rem;
+  }
+
   :dir(rtl) .input-with-clear {
     padding-left: 3rem;
+    padding-right: 0.75rem;
+  }
+
+  :dir(rtl) .input-with-clear-compact {
+    padding-left: 2.5rem;
     padding-right: 0.75rem;
   }
 


### PR DESCRIPTION
## Summary
- Add a reusable `PasteButton` and show it contextually in Split/Combine inputs only when fields are empty, swapping back to clear actions once content exists.
- Gate paste button rendering behind direct clipboard-read capability checks so unsupported/mobile-prompt flows are hidden instead of exposing unreliable UX.
- Refine inline action styling for compact passphrase fields and remove action backdrops, leaving subtle icon-only highlight while preserving LTR/RTL layout behavior.

## Validation
- `bunx tsc --noEmit`
- `bun run build`